### PR TITLE
Limit search engine document crawling

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /documents/
 
 Sitemap: https://www.klubfitpp.cz/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://www.klubfitpp.cz</loc>
-        <lastmod>2021-12-31</lastmod>
+        <lastmod>2022-04-12</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1</priority>
     </url>


### PR DESCRIPTION
Approved by @SoptikHa2
Limits pdf crawling, should be enough with server header settings. Thx @antoninkriz 