### PR TITLE
Change body w-display to w-full

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="cs-CZ">
 {% include head.html %}
-  <body class="w-screen max-w-screen min-h-screen overflow-x-hidden overflow-y-auto bg-slate-50">
+  <body class="w-full max-w-screen min-h-screen overflow-x-hidden overflow-y-auto bg-slate-50">
     {{ content }}
   </body>
 {% include foot.html %}


### PR DESCRIPTION
Fixes unintended horizontal scroll imposed by the scroll bar width, see video.

This changes
```css
body {
    width: 100vw;
}
```
to
```css
body {
    width: 100%;
}
```
see [Tailwind docs](https://tailwindcss.com/docs/width).

Mouse pointer is not visible and the video might break down when fast forwarding/jumping due to linux skill issue, sorry.

https://github.com/user-attachments/assets/49e2ad14-a8ea-496a-ad3a-26b605a197db

https://github.com/user-attachments/assets/7110b82e-c9a0-4f67-9830-c6dbf540ca9d
