### PR TITLE
feat(feed): Implement Atom (RSS) feed for events and news articles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -57,3 +57,5 @@ default_lang: "cs"
 exclude_from_localization: ["javascript", "images", "css", "public", "sitemap"]
 parallel_localization: true
 lang_from_path: true
+feed:
+  limit: 20

--- a/feed/events.xml
+++ b/feed/events.xml
@@ -1,0 +1,35 @@
+---
+layout: none
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml"/>
+  <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ page.url | absolute_url }}</id>
+  <title type="html">{{ site.title }} | Events</title>
+  <author>
+    <name>{{ site.title }}</name>
+  </author>
+  {% assign all_events = site.events | sort: "date" | reverse %}
+  {% assign events = all_events | slice: 0, site.feed.limit %}
+  {% for event in events %}
+  <entry>
+    <title type="html">{{ event.title | xml_escape }}</title>
+    <link href="{{ event.url | absolute_url }}" rel="alternate" type="text/html" title="{{ event.title | xml_escape }}"/>
+    <published>{{ event.date | date_to_xmlschema }}</published>
+    <updated>{{ event.date | date_to_xmlschema }}</updated>
+    <id>{{ event.url | absolute_url }}</id>
+    <content type="html" xml:base="{{ event.url | absolute_url }}"><![CDATA[{{ event.content }}]]></content>
+    <summary type="html"><![CDATA[{{ event.content | strip_html | normalize_whitespace | truncatewords: 50 }}]]></summary>
+    {% if event.img %}
+    <media:content url="{{ event.img | absolute_url }}" medium="image"/>
+    {% endif %}
+    {% assign categories = event.categories | uniq %}
+    {% for category in categories %}
+    <category term="{{ category | xml_escape }}"/>
+    {% endfor %}
+  </entry>
+  {% endfor %}
+</feed>

--- a/feed/news.xml
+++ b/feed/news.xml
@@ -1,0 +1,35 @@
+---
+layout: none
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
+  <generator uri="https://jekyllrb.com/" version="{{ jekyll.version }}">Jekyll</generator>
+  <link href="{{ page.url | absolute_url }}" rel="self" type="application/atom+xml"/>
+  <link href="{{ '/' | absolute_url }}" rel="alternate" type="text/html"/>
+  <updated>{{ site.time | date_to_xmlschema }}</updated>
+  <id>{{ page.url | absolute_url }}</id>
+  <title type="html">{{ site.title }} | News</title>
+  <author>
+    <name>{{ site.title }}</name>
+  </author>
+  {% assign all_articles = site.news | sort: "date" | reverse %}
+  {% assign articles = all_articles | slice: 0, site.feed.limit %}
+  {% for article in articles %}
+  <entry>
+    <title type="html">{{ article.title | xml_escape }}</title>
+    <link href="{{ article.url | absolute_url }}" rel="alternate" type="text/html" title="{{ article.title | xml_escape }}"/>
+    <published>{{ article.date | date_to_xmlschema }}</published>
+    <updated>{{ article.date | date_to_xmlschema }}</updated>
+    <id>{{ article.url | absolute_url }}</id>
+    <content type="html" xml:base="{{ article.url | absolute_url }}"><![CDATA[{{ article.content }}]]></content>
+    <summary type="html"><![CDATA[{{ article.short | default: article.content | strip_html | normalize_whitespace | truncatewords: 50 }}]]></summary>
+    {% if article.img %}
+    <media:content url="{{ article.img | absolute_url }}" medium="image"/>
+    {% endif %}
+    {% assign categories = article.categories | uniq %}
+    {% for category in categories %}
+    <category term="{{ category | xml_escape }}"/>
+    {% endfor %}
+  </entry>
+  {% endfor %}
+</feed>


### PR DESCRIPTION
Implemented an Atom (modern RSS) feed for events and news articles.

The XML feed files are at:
- `/feed/events.xml`
- `/feed/news.xml`
- `/en/feed/events.xml`
- `/en/feed/news.xml`

English posts/articles that do not have a translation yet fallback to Czech language - the same behaviour as the website.

Number of feed entries is limited by a config variable `feed.limit` in the `_config.yml` file (currently set to 20).

I tested this locally on the [Feeder mobile app](https://play.google.com/store/apps/details?id=com.nononsenseapps.feeder.play) and it looked like everything *should* work.

(Yes, I know I could have used `jekyll-feed` but it was not working correctly with images and `polyglot`)